### PR TITLE
Expect a null temperature setting when heating is disabled

### DIFF
--- a/src/tado/model.rs
+++ b/src/tado/model.rs
@@ -32,7 +32,7 @@ pub struct ZoneStateApiResponse {
 #[derive(Deserialize, Debug)]
 #[allow(non_snake_case)]
 pub struct ZoneStateSettingApiResponse {
-    pub temperature: ZoneStateSettingTemperatureApiResponse,
+    pub temperature: Option<ZoneStateSettingTemperatureApiResponse>,
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
Thank you for writing tado-exporter! 😊

This PR wraps the `ZoneStateSettingTemperatureApiResponse` type in an Option type, to allow a null response from the tado API.

I discovered that the API will return a null temperature setting (at JSON path `$.setting.temperature`) if the heating mode is disabled. This causes an error while unmarshaling the API response:

```
[2020-05-21T16:52:57Z INFO  tado_exporter::tado::client] retrieving zone details for Heating...
[2020-05-21T16:52:57Z ERROR tado_exporter::tado::client] unable to retrieve home zone 'Heating' state: error decoding response body: invalid type: null, expected struct ZoneStateSettingTemperatureApiResponse at line 1 column 164
```

Here's a cut down example of what the API returns for me when I query it manually, when the heating is enabled:
```
curl -s "https://my.tado.com/api/v2/homes/.../zones/1/state" | jq .setting
{
  "temperature": {
    "fahrenheit": 68,
    "celsius": 20
  },
  "power": "ON",
  "type": "HEATING"
}
```

Versus when the heating is disabled:
```
curl -s "https://my.tado.com/api/v2/homes/.../zones/1/state" | jq .setting
{
  "temperature": null,
  "power": "OFF",
  "type": "HEATING"
}
```

I've not written rust before, so please let me know if there's anything un-idiomatic 😄 

The approach I've taken is to just skip setting the gauge in this case. This does feel like it is misrepresenting the true state, as the gauge value will remain set to the previous value even though the heating is not enabled. It might be worth adding another gauge for "heating enabled" with a fixed value of 0 or 1. What do you think? I'm happy to contribute that in a follow-up if you think it's reasonable.