### PR TITLE
Not printing password

### DIFF
--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -12,7 +12,7 @@ impl Config {
         println!("--- tado° exporter configuration ---");
         println!("Ticker seconds: {}", self.ticker);
         println!("Username: {}", self.username);
-        println!("Password: {}", self.password);
+        println!("Password: <not printed>");
         println!("Client secret: {}", self.client_secret);
         println!("------------------------------------");
     }


### PR DESCRIPTION
Preventing tado-exporter from printing my password into log - some might want this.

Using a systemd service file, the username password can be supplied via the EnvironmentFile directive in file only readable by root.