### PR TITLE
Shuffled Docker operation to reduce build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
 FROM rust:latest AS builder
 
 WORKDIR /usr/src/tado-exporter
-COPY . .
 
 RUN apt-get update && \
     apt-get -y install ca-certificates libssl-dev musl-tools && \
     rm -rf /var/lib/apt/lists/*
 
 RUN rustup target add x86_64-unknown-linux-musl
+
+COPY Cargo.* .
+COPY src/ ./src
+
 RUN cargo build --target x86_64-unknown-linux-musl --release
 
 FROM scratch


### PR DESCRIPTION
- Moved the copy files operation as late as possible to not bust the cache 
- Copy only the file needed to avoid busting the cache because unrelated files are changed