### PR TITLE
Don't fail test if env vars are already set

### DIFF
--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -49,6 +49,12 @@ mod tests {
 
     #[test]
     fn test_config_load() {
+        // Given no env variable are set
+        env::remove_var("EXPORTER_USERNAME");
+        env::remove_var("EXPORTER_PASSWORD");
+        env::remove_var("EXPORTER_TICKER");
+        env::remove_var("EXPORTER_CLIENT_SECRET");
+
         // when
         let config = load();
 


### PR DESCRIPTION
Stops the test failing if the env variables are already set in the terminal prior running the test.