### PR TITLE
Use cycle() to have an real infinite loop

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ fn run_ticker(config: config_loader::Config) {
 
         info!("waiting for the first tick in {} seconds...", config.ticker);
 
-        let ticker = Ticker::new(0.., Duration::from_secs(config.ticker));
+        let ticker = Ticker::new((0..).cycle(), Duration::from_secs(config.ticker));
         for _ in ticker {
             metrics::set(tado_client.retrieve().await);
         }


### PR DESCRIPTION
By using `cycle()` the iterator becomes really infinite and will wrap around when reach the upper bound of the `i32` type.