### PR TITLE
Add gauge for open window sensor reading

### DIFF
--- a/src/tado/client.rs
+++ b/src/tado/client.rs
@@ -209,9 +209,9 @@ mod tests {
     use crate::tado::model::{
         ActivityDataPointsHeatingPowerApiResponse, SensorDataPointsHumidityApiResponse,
         SensorDataPointsInsideTemperatureApiResponse, WeatherOutsideTemperatureApiResponse,
-        WeatherSolarIntensityApiResponse, ZoneStateApiResponse,
-        ZoneStateSensorDataPointsApiResponse, ZoneStateSettingApiResponse,
-        ZoneStateSettingApiResponse, ZoneStateSettingTemperatureApiResponse,
+        WeatherSolarIntensityApiResponse, ZoneStateActivityDataPointsApiResponse,
+        ZoneStateApiResponse, ZoneStateSensorDataPointsApiResponse, ZoneStateSettingApiResponse,
+        ZoneStateSettingTemperatureApiResponse,
     };
 
     use rstest::*;

--- a/src/tado/client.rs
+++ b/src/tado/client.rs
@@ -328,7 +328,7 @@ mod tests {
                   },
                   "acPower":null
                 },
-                "openWindowDetection":true,
+                "openWindowDetected":true,
                 "sensorDataPoints":{
                   "insideTemperature":{
                     "celsius":25.0,
@@ -353,7 +353,7 @@ mod tests {
                     }),
                     acPower : None
                 },
-                openWindowDetection: Some(true),
+                openWindowDetected: Some(true),
                 sensorDataPoints: ZoneStateSensorDataPointsApiResponse {
                     insideTemperature : Some(SensorDataPointsInsideTemperatureApiResponse {
                         celsius: 25.0,
@@ -404,7 +404,7 @@ mod tests {
                     }),
                     acPower : None
                 },
-                openWindowDetection: None,
+                openWindowDetected: None,
                 sensorDataPoints: ZoneStateSensorDataPointsApiResponse {
                     insideTemperature : Some(SensorDataPointsInsideTemperatureApiResponse {
                         celsius: 25.0,

--- a/src/tado/metrics.rs
+++ b/src/tado/metrics.rs
@@ -50,6 +50,12 @@ lazy_static! {
         &["unit"]
     )
     .unwrap();
+    pub static ref SENSOR_WINDOW_OPENED: GaugeVec = register_gauge_vec!(
+        "tado_sensor_window_opened",
+        "1 if the sensor detected a window is open, 0 otherwise.",
+        &["zone", "type"]
+    )
+    .unwrap();
 }
 
 pub fn set_zones(zones: Vec<ZoneStateResponse>) {
@@ -93,6 +99,29 @@ pub fn set_zones(zones: Vec<ZoneStateResponse>) {
                 zone.name,
                 device_type.as_str()
             );
+        }
+
+        // If openWindowDetected is not None, this means that a window is open.
+        if zone.state_response.openWindowDetection.is_some() {
+            info!(
+                "-> {} ({}) -> window opened: {}",
+                zone.name,
+                device_type.as_str(),
+                true
+            );
+            SENSOR_WINDOW_OPENED
+                .with_label_values(&[zone.name.as_str(), device_type.as_str()])
+                .set(1.0);
+        } else {
+            info!(
+                "-> {} ({}) -> window opened: {}",
+                zone.name,
+                device_type.as_str(),
+                false
+            );
+            SENSOR_WINDOW_OPENED
+                .with_label_values(&[zone.name.as_str(), device_type.as_str()])
+                .set(0.0);
         }
 
         // sensor temperature

--- a/src/tado/metrics.rs
+++ b/src/tado/metrics.rs
@@ -102,7 +102,7 @@ pub fn set_zones(zones: Vec<ZoneStateResponse>) {
         }
 
         // If openWindowDetected is not None, this means that a window is open.
-        if zone.state_response.openWindowDetection.is_some() {
+        if zone.state_response.openWindowDetected.is_some() {
             info!(
                 "-> {} ({}) -> window opened: {}",
                 zone.name,

--- a/src/tado/model.rs
+++ b/src/tado/model.rs
@@ -28,7 +28,7 @@ pub struct ZoneStateApiResponse {
     pub activityDataPoints: ZoneStateActivityDataPointsApiResponse,
     pub sensorDataPoints: ZoneStateSensorDataPointsApiResponse,
     // pub openWindow: Option<ZoneStateOpenWindowApiResponse>,
-    pub openWindowDetection: Option<bool>,
+    pub openWindowDetected: Option<bool>,
 }
 
 #[derive(Deserialize, Debug, PartialEq)]

--- a/src/tado/model.rs
+++ b/src/tado/model.rs
@@ -21,17 +21,17 @@ pub struct ZonesApiResponse {
     pub name: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq)]
 #[allow(non_snake_case)]
 pub struct ZoneStateApiResponse {
     pub setting: ZoneStateSettingApiResponse,
     pub activityDataPoints: ZoneStateActivityDataPointsApiResponse,
     pub sensorDataPoints: ZoneStateSensorDataPointsApiResponse,
     // pub openWindow: Option<ZoneStateOpenWindowApiResponse>,
-    // pub openWindowDetection: Option<?>,
+    pub openWindowDetection: Option<bool>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq)]
 #[allow(non_snake_case)]
 pub struct ZoneStateSettingApiResponse {
     #[serde(rename = "type")]
@@ -39,43 +39,43 @@ pub struct ZoneStateSettingApiResponse {
     pub temperature: Option<ZoneStateSettingTemperatureApiResponse>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq)]
 pub struct ZoneStateSettingTemperatureApiResponse {
     pub celsius: f64,
     pub fahrenheit: f64,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq)]
 #[allow(non_snake_case)]
 pub struct ZoneStateActivityDataPointsApiResponse {
     pub heatingPower: Option<ActivityDataPointsHeatingPowerApiResponse>,
     pub acPower: Option<ActivityDataPointsAcPowerApiResponse>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq)]
 pub struct ActivityDataPointsHeatingPowerApiResponse {
     pub percentage: f64,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq)]
 pub struct ActivityDataPointsAcPowerApiResponse {
     pub value: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq)]
 #[allow(non_snake_case)]
 pub struct ZoneStateSensorDataPointsApiResponse {
     pub insideTemperature: Option<SensorDataPointsInsideTemperatureApiResponse>,
     pub humidity: Option<SensorDataPointsHumidityApiResponse>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq)]
 pub struct SensorDataPointsInsideTemperatureApiResponse {
     pub celsius: f64,
     pub fahrenheit: f64,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq)]
 pub struct SensorDataPointsHumidityApiResponse {
     pub percentage: f64,
 }

--- a/src/tado/model.rs
+++ b/src/tado/model.rs
@@ -57,7 +57,7 @@ pub struct ActivityDataPointsHeatingPowerApiResponse {
     pub percentage: f64,
 }
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, PartialEq, Eq)]
 pub struct ActivityDataPointsAcPowerApiResponse {
     pub value: String,
 }


### PR DESCRIPTION
Added a new metric, `tado_sensor_window_opened{zone, type}` which is set to 1 when window detection reports an open window, and 0 otherwise.