### PR TITLE
fix: Correct format of Bearer authentication header

### DIFF
--- a/src/tado/client.rs
+++ b/src/tado/client.rs
@@ -68,7 +68,7 @@ impl Client {
     async fn get(&self, url: reqwest::Url) -> Result<reqwest::Response, reqwest::Error> {
         self.http_client
             .get(url)
-            .header("Authorization", format!("Bearer: {}", self.access_token))
+            .header("Authorization", format!("Bearer {}", self.access_token))
             .send()
             .await
     }


### PR DESCRIPTION
Hi :wave:

I recently noticed that around the 21st of August the exporter stopped refreshing my heating information.

I discovered the issue is around failing to authenticate.
Executing the same API calls the exporter performs in another REST client worked.
The only difference between the request is `Bearer:` (from the code) vs `Bearer` (from my REST client).

This PR removes the `:` after `Bearer` in the authentication header, which fixes the issue.
Looking at the [RFC](https://datatracker.ietf.org/doc/html/rfc6750#section-2.1) the `:` is not expected.

Given this broke without changes on my side I expect Tado updated their systems and new version rejects `Bearer:` while the old one allowed it :shrug: 

I hope this helps and thanks for the useful project,
Stefano