### PR TITLE
chore: Rework authentication to use device flow

### DIFF
--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -4,7 +4,7 @@ pub struct Config {
     pub ticker: u64,
     pub username: String,
     pub password: String,
-    pub client_secret: String,
+    pub client_id: String,
 }
 
 impl Config {
@@ -13,7 +13,7 @@ impl Config {
         println!("Ticker seconds: {}", self.ticker);
         println!("Username: {}", self.username);
         println!("Password: <not printed>");
-        println!("Client secret: {}", self.client_secret);
+        println!("Client ID: {}", self.client_id);
         println!("------------------------------------");
     }
 }
@@ -32,10 +32,10 @@ pub fn load() -> Config {
             Ok(v) => v,
             Err(_) => "".to_string(),
         },
-        client_secret: match env::var("EXPORTER_CLIENT_SECRET") {
+        client_id: match env::var("EXPORTER_CLIENT_ID") {
             Ok(v) => v,
             Err(_) => {
-                "wZaRN7rpjn3FoNyF5IFuxg9uMzYJcvOoQ8QWiIqS3hfk6gLhVlG57j5YNoZL2Rtc".to_string()
+                "1bb50063-6b0c-4d11-bd99-387f4a91cc46".to_string()
             }
         },
     };
@@ -55,7 +55,7 @@ mod tests {
         env::remove_var("EXPORTER_USERNAME");
         env::remove_var("EXPORTER_PASSWORD");
         env::remove_var("EXPORTER_TICKER");
-        env::remove_var("EXPORTER_CLIENT_SECRET");
+        env::remove_var("EXPORTER_CLIENT_ID");
 
         // when
         let config = load();
@@ -65,15 +65,15 @@ mod tests {
         assert_eq!(config.username, "");
         assert_eq!(config.password, "");
         assert_eq!(
-            config.client_secret,
-            "wZaRN7rpjn3FoNyF5IFuxg9uMzYJcvOoQ8QWiIqS3hfk6gLhVlG57j5YNoZL2Rtc"
+            config.client_id,
+            "1bb50063-6b0c-4d11-bd99-387f4a91cc46"
         );
 
         // given the following environment variable values
         env::set_var("EXPORTER_USERNAME", "test-user");
         env::set_var("EXPORTER_PASSWORD", "123Password!");
         env::set_var("EXPORTER_TICKER", "30");
-        env::set_var("EXPORTER_CLIENT_SECRET", "123-secret");
+        env::set_var("EXPORTER_CLIENT_ID", "client-123");
 
         // when
         let config = load();
@@ -82,6 +82,6 @@ mod tests {
         assert_eq!(config.ticker, 30);
         assert_eq!(config.username, "test-user");
         assert_eq!(config.password, "123Password!");
-        assert_eq!(config.client_secret, "123-secret");
+        assert_eq!(config.client_id, "client-123");
     }
 }

--- a/src/tado/client.rs
+++ b/src/tado/client.rs
@@ -1,74 +1,99 @@
+use std::time::{Duration, Instant};
+use std::vec::Vec;
+
 use lazy_static::lazy_static;
 use log::{error, info};
 use reqwest;
-use std::vec::Vec;
 
+use super::error::AuthError;
 use super::model::{
-    AuthApiResponse, MeApiResponse, WeatherApiResponse, ZoneStateApiResponse, ZoneStateResponse,
-    ZonesApiResponse,
+    AuthStartResponse, AuthTokensErrorResponse, AuthTokensResponse, MeApiResponse,
+    WeatherApiResponse, ZoneStateApiResponse, ZoneStateResponse, ZonesApiResponse,
 };
 
+const AUTH_PENDING_MESSAGE: &str = "authorization_pending";
+
 lazy_static! {
-    static ref AUTH_URL: reqwest::Url = "https://auth.tado.com/oauth/token".parse().unwrap();
+    // TODO: POST DEVICE - https://login.tado.com/oauth2/device
+    static ref AUTH_START_URL: reqwest::Url = "https://login.tado.com/oauth2/device_authorize".parse().unwrap();
+    static ref AUTH_TOKEN_URL: reqwest::Url = "https://login.tado.com/oauth2/token".parse().unwrap();
     pub static ref BASE_URL: reqwest::Url = "https://my.tado.com/api/v2/".parse().unwrap();
 }
 
 pub struct Client {
     http_client: reqwest::Client,
     base_url: reqwest::Url,
+
+    // API Authentication information.
     username: String,
     password: String,
-    client_secret: String,
-    access_token: String,
+    client_id: String,
+    tokens: AuthTokensResponse,
+    tokens_refresh_by: Instant,
+
     home_id: i32,
 }
 
 impl Client {
-    pub fn new(username: String, password: String, client_secret: String) -> Client {
-        Client::with_base_url(BASE_URL.clone(), username, password, client_secret)
+    pub fn new(username: String, password: String, client_id: String) -> Client {
+        Client::with_base_url(BASE_URL.clone(), username, password, client_id)
     }
 
     fn with_base_url(
         base_url: reqwest::Url,
         username: String,
         password: String,
-        client_secret: String,
+        client_id: String,
     ) -> Client {
         Client {
             http_client: reqwest::Client::new(),
             base_url,
             username,
             password,
-            client_secret,
-            access_token: String::default(),
+            client_id,
+            tokens: AuthTokensResponse {
+                access_token: String::default(),
+                expires_in: 0,
+                refresh_token: String::default(),
+            },
+            tokens_refresh_by: Instant::now(),
             home_id: 0,
         }
     }
 
-    async fn authenticate(&mut self) -> Result<AuthApiResponse, reqwest::Error> {
-        let params = [
-            ("client_id", "tado-web-app"),
-            ("client_secret", self.client_secret.as_str()),
-            ("grant_type", "password"),
-            ("scope", "home.user"),
-            ("username", self.username.as_str()),
-            ("password", self.password.as_str()),
+    /// Authenticate to the Tado API service.
+    ///
+    /// The authentication processes uses the oauth2 device code grant flow as required by Tado
+    /// <https://support.tado.com/en/articles/8565472-how-do-i-authenticate-to-access-the-rest-api>.
+    ///
+    /// To avoid manual intervention, the method also attempts to complete the login challenge
+    /// on behalf of the user.
+    pub async fn authenticate(&mut self) -> Result<(), AuthError> {
+        // Start device authentication flow.
+        let start_params = [
+            ("client_id", self.client_id.as_str()),
+            ("scope", "offline_access"),
         ];
-
         let resp = self
             .http_client
-            .post(AUTH_URL.clone())
-            .form(&params)
+            .post(AUTH_START_URL.clone())
+            .form(&start_params)
             .send()
             .await?;
+        let start = resp.json::<AuthStartResponse>().await?;
+        info!("Started device authentication flow with URL {}", start.verification_uri_complete);
 
-        resp.json::<AuthApiResponse>().await
+        // TODO: run through login flow.
+
+        // Wait for API tokens to be returned once the flow is complete.
+        self.wait_for_tokens(start).await?;
+        Ok(())
     }
 
     async fn get(&self, url: reqwest::Url) -> Result<reqwest::Response, reqwest::Error> {
         self.http_client
             .get(url)
-            .header("Authorization", format!("Bearer {}", self.access_token))
+            .header("Authorization", format!("Bearer {}", self.tokens.access_token))
             .send()
             .await
     }
@@ -107,18 +132,31 @@ impl Client {
         resp.json::<WeatherApiResponse>().await
     }
 
+    /// Refresh the API access token if it expired.
+    pub async fn refresh_authentication(&mut self) -> Result<(), AuthError> {
+        if Instant::now() < self.tokens_refresh_by {
+            return Ok(());
+        }
+
+        let refresh_params = [
+            ("client_id", self.client_id.as_str()),
+            ("grant_type", "refresh_token"),
+            ("refresh_token", self.tokens.refresh_token.as_str()),
+        ];
+        let resp = self
+            .http_client
+            .post(AUTH_TOKEN_URL.clone())
+            .form(&refresh_params)
+            .send()
+            .await?;
+
+        let tokens = resp.json::<AuthTokensResponse>().await?;
+        self.set_tokens(tokens);
+        info!("API access tokens refreshed");
+        Ok(())
+    }
+
     pub async fn retrieve_zones(&mut self) -> Vec<ZoneStateResponse> {
-        // retrieve an access token to use the tado API
-        let api_response = match self.authenticate().await {
-            Ok(resp) => resp,
-            Err(e) => {
-                error!("unable to authenticate: {}", e);
-                return Vec::new();
-            }
-        };
-
-        self.access_token = api_response.access_token;
-
         // retrieve home details (only if we don't already have a home identifier)
         if self.home_id == 0 {
             let me_response = match self.me().await {
@@ -165,16 +203,6 @@ impl Client {
     pub async fn retrieve_weather(&mut self) -> Option<WeatherApiResponse> {
         info!("retrieving weather details ...");
 
-        let api_response = match self.authenticate().await {
-            Ok(resp) => resp,
-            Err(e) => {
-                error!("unable to authenticate: {}", e);
-                return None;
-            }
-        };
-
-        self.access_token = api_response.access_token;
-
         // retrieve home details (only if we don't already have a home identifier)
         if self.home_id == 0 {
             let me_response = match self.me().await {
@@ -198,6 +226,57 @@ impl Client {
         };
 
         Some(weather_response)
+    }
+
+    /// Set the API access tokens to use and manage related metadata.
+    fn set_tokens(&mut self, tokens: AuthTokensResponse) {
+        // Reduce the tokens validity slightly to refresh before they expire.
+        let expires_in = tokens.expires_in - 10;
+        self.tokens = tokens;
+        self.tokens_refresh_by = Instant::now() + Duration::from_secs(expires_in);
+    }
+
+    async fn wait_for_tokens(&mut self, start: AuthStartResponse) -> Result<(), AuthError> {
+        let must_complete_by = Instant::now() + Duration::from_secs(start.expires_in);
+        let token_params = [
+            ("client_id", self.client_id.as_str()),
+            ("device_code", &start.device_code),
+            ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+        ];
+        while Instant::now() < must_complete_by {
+            let resp = self
+                .http_client
+                .post(AUTH_TOKEN_URL.clone())
+                .form(&token_params)
+                .send()
+                .await?;
+            match resp.status() {
+                reqwest::StatusCode::OK => {
+                    let tokens = resp.json::<AuthTokensResponse>().await?;
+                    self.set_tokens(tokens);
+                    info!("Device authentication flow completed");
+                    return Ok(());
+                }
+                reqwest::StatusCode::BAD_REQUEST => {
+                    let error = resp
+                        .error_for_status_ref()
+                        .expect_err("must be error for BAD_REQUEST");
+                    let failure = resp.json::<AuthTokensErrorResponse>().await?;
+                    if failure.error != AUTH_PENDING_MESSAGE {
+                        return Err(AuthError::from(error));
+                    }
+                }
+                _ => {
+                    let status = resp.status();
+                    let url = resp.url().clone();
+                    resp.error_for_status()?;
+                    return Err(AuthError::UnexpectedStatus(status, url));
+                }
+            }
+            info!("Device authentication flow still pending, will retry");
+            tokio::time::sleep(Duration::from_secs(start.interval)).await;
+        }
+        Err(AuthError::Timeout)
     }
 }
 
@@ -223,12 +302,12 @@ mod tests {
         let client = Client::new(
             "username".to_string(),
             "password".to_string(),
-            "client_secret".to_string(),
+            "client_id".to_string(),
         );
 
         assert_eq!(client.username, "username");
         assert_eq!(client.password, "password");
-        assert_eq!(client.client_secret, "client_secret");
+        assert_eq!(client.client_id, "client_id");
         assert_eq!(client.base_url, *BASE_URL);
     }
 
@@ -238,12 +317,12 @@ mod tests {
             "https://example.com".parse().unwrap(),
             "username".to_string(),
             "password".to_string(),
-            "client_secret".to_string(),
+            "client_id".to_string(),
         );
 
         assert_eq!(client.username, "username");
         assert_eq!(client.password, "password");
-        assert_eq!(client.client_secret, "client_secret");
+        assert_eq!(client.client_id, "client_id");
         assert_eq!(client.base_url, "https://example.com".parse().unwrap());
     }
 

--- a/src/tado/error.rs
+++ b/src/tado/error.rs
@@ -1,0 +1,47 @@
+use reqwest::{
+    Error as HttpError,
+    StatusCode,
+    Url,
+};
+
+/// Authentication Errors.
+#[derive(Debug)]
+pub enum AuthError {
+    /// Authentication failed because of an HTTP client error.
+    Http(HttpError),
+
+    /// The device authentication flow took too long to complete.
+    Timeout,
+
+    /// Unexpected status from the Auth API.
+    UnexpectedStatus(StatusCode, Url),
+}
+
+impl std::fmt::Display for AuthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AuthError::Http(inner) => std::fmt::Display::fmt(inner, f),
+            AuthError::Timeout => write!(f, "device auth flow took too long to complete"),
+            AuthError::UnexpectedStatus(status, url) => write!(
+                f, "unexpected auth API status {} for URL {}",
+                status, url,
+            ),
+        }
+    }
+}
+
+impl std::error::Error for AuthError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            AuthError::Http(ref inner) => Some(inner),
+            AuthError::Timeout => None,
+            AuthError::UnexpectedStatus(_, _) => None,
+        }
+    }
+}
+
+impl From<HttpError> for AuthError {
+    fn from(value: HttpError) -> Self {
+        AuthError::Http(value)
+    }
+}

--- a/src/tado/mod.rs
+++ b/src/tado/mod.rs
@@ -1,3 +1,4 @@
 pub mod client;
+pub mod error;
 pub mod metrics;
 pub mod model;

--- a/src/tado/model.rs
+++ b/src/tado/model.rs
@@ -1,8 +1,23 @@
 use serde_derive::Deserialize;
 
 #[derive(Deserialize, Debug)]
-pub struct AuthApiResponse {
+pub struct AuthStartResponse {
+    pub device_code: String,
+    pub expires_in: u64,
+    pub interval: u64,
+    pub verification_uri_complete: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct AuthTokensErrorResponse {
+    pub error: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct AuthTokensResponse {
     pub access_token: String,
+    pub expires_in: u64,
+    pub refresh_token: String,
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
This is now required by the Tado API service.
With this commit the authentication method uses OAuth2 device flow and the user is required to complete the authentication with the printed URL.

Not sure if this should be merged until a fully automated solution works, but wanted to share as a workaround since the current authentication method will be broken soon.

## New flow manual step

The current requirement of manual intervention is because of how the device flow works.

When the exporter starts, it will start the login flow and log the URL to complete the flow.
You will have to open that link in a browser and login.

This also needs to happen within 5 minutes of the process starting up.
After that the authentication codes expire and the process needs to be restarted.

## Automating login

I've tried to add logic to automate the login step but it is not working and I'm out of time for now.

For anyone interested the auto-login code is on [this branch](https://github.com/stefano-pogliani/tado-exporter/tree/fix/auth-auto).
When I try to `POST` to the authorize endpoint with information the devtools in my browser points me to says the Web App is sending I get back a login form.
I guess something is missing to "complete the flow" and Tado API rejects my login attempt :shrug: